### PR TITLE
180089 Handle errors in card merging

### DIFF
--- a/card_generator/cards/tests/test_tasks.py
+++ b/card_generator/cards/tests/test_tasks.py
@@ -20,7 +20,7 @@ class TestMergeCardTask(OpenSPPClientTestMixin, TestCase):
         mock_get_id_queue_pdfs,
         mock_update_queue_batch_record,
     ):
-        mock_get_queue_batch.return_value = [self.sample_queue_batch]
+        mock_get_queue_batch.return_value = self.sample_queue_batch
         mock_get_id_queue_pdfs.return_value = [
             self.sample_id_queue,
             self.sample_id_queue,
@@ -37,7 +37,7 @@ class TestMergeCardTask(OpenSPPClientTestMixin, TestCase):
     @mock.patch("card_generator.cards.client.logger")
     @mock.patch("card_generator.cards.client.QueueCardsClient.get_queue_batch")
     def test_merge_card_no_id_queue(self, mock_get_queue_batch, mock_logger):
-        mock_get_queue_batch.return_value = [{}]
+        mock_get_queue_batch.return_value = {"name": "no_id_queue", "id": 1}
         client = QueueCardsClient(
             server_root=settings.OPENSPP_SERVER_ROOT,
             username=settings.OPENSPP_USERNAME,
@@ -47,10 +47,10 @@ class TestMergeCardTask(OpenSPPClientTestMixin, TestCase):
         perform_merging(client, 1)
         mock_logger.info.assert_called_with("Batch ID 1 don't have queue IDs.")
 
-    @mock.patch("card_generator.cards.client.logger")
+    @mock.patch("card_generator.tasks.cards.logger")
     @mock.patch("card_generator.cards.client.QueueCardsClient.get_queue_batch")
     def test_merge_card_no_queue_batch(self, mock_get_queue_batch, mock_logger):
-        mock_get_queue_batch.return_value = []
+        mock_get_queue_batch.return_value = None
         client = QueueCardsClient(
             server_root=settings.OPENSPP_SERVER_ROOT,
             username=settings.OPENSPP_USERNAME,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,13 @@
 [pytest]
-addopts = --ds=config.settings.test --reuse-db
 python_files = tests.py test_*.py
+pythonwarnings = default
+addopts =
+    -v
+    --ds=config.settings.test
+    --reuse-db
+    --tb=short
+    --capture=no
+    --cov-report=xml
+    --cov-report=html
+    --cov=pdsspp_translator
+    --cov-config=.coveragerc

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -11,6 +11,7 @@ django-stubs==1.12.0  # https://github.com/typeddjango/django-stubs
 pytest==7.1.3  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.5  # https://github.com/Frozenball/pytest-sugar
 djangorestframework-stubs==1.7.0  # https://github.com/typeddjango/djangorestframework-stubs
+pytest-cov>=3.0.0
 
 # Documentation
 # ------------------------------------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,18 @@ ignore_errors = True
 
 [coverage:run]
 include = card_generator/*
-omit = *migrations*, *tests*
+omit =
+    *migrations*
+    *tests*
+    *venv*
+    *docs*
+    manage.py
+    .*
+    *templates*
+    *media*
+    compose/*
+    config/*
+    requirements/*
+    merge_production_dotenvs_in_dotenv.py
 plugins =
     django_coverage_plugin


### PR DESCRIPTION
- [ ] When an exception is raised on tasks queue, update the `merge_status` of queue batch record to `error_merging `
- [ ] When merge is successful, update `merge_status` to `merged `