### PR TITLE
184792 Set date merge in queue batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,9 @@ env:
 
 on:
   pull_request:
-    branches: [ "master", "main" ]
     paths-ignore: [ "docs/**" ]
 
   push:
-    branches: [ "master", "main" ]
     paths-ignore: [ "docs/**" ]
 
 concurrency:

--- a/card_generator/api/tests/v1/cards/test_api_v1.py
+++ b/card_generator/api/tests/v1/cards/test_api_v1.py
@@ -331,8 +331,12 @@ class CardDetailTestCase(APITestCase):
         with self.assertRaises(QRCodeCharLimitException):
             self.client.post(self.render_url, data, format="json")
 
+    @mock.patch("card_generator.cards.client.QueueCardsClient.get_queue_batch")
+    @mock.patch("card_generator.cards.client.QueueCardsClient.login")
     @mock.patch("card_generator.tasks.cards.merge_cards.delay")
-    def test_merge_cards(self, mock_task):
+    def test_merge_cards(self, mock_task, mock_login, mock_get_queue_batch):
+        mock_login.return_value = 1
+        mock_get_queue_batch.return_value = {"id": 1}
         data = {"batch_id": 1}
         response = self.client.post(self.merge_cards_url, data=data, format="json")
         self.assertEqual(200, response.status_code)

--- a/card_generator/cards/tests/test_tasks.py
+++ b/card_generator/cards/tests/test_tasks.py
@@ -9,6 +9,7 @@ from card_generator.tasks.cards import perform_merging
 
 
 class TestMergeCardTask(OpenSPPClientTestMixin, TestCase):
+    @mock.patch("card_generator.cards.client.QueueCardsClient.login")
     @mock.patch(
         "card_generator.cards.client.QueueCardsClient.update_queue_batch_record"
     )
@@ -19,7 +20,9 @@ class TestMergeCardTask(OpenSPPClientTestMixin, TestCase):
         mock_get_queue_batch,
         mock_get_id_queue_pdfs,
         mock_update_queue_batch_record,
+        mock_login,
     ):
+        mock_login.return_value = 1
         mock_get_queue_batch.return_value = self.sample_queue_batch
         mock_get_id_queue_pdfs.return_value = [
             self.sample_id_queue,
@@ -34,10 +37,14 @@ class TestMergeCardTask(OpenSPPClientTestMixin, TestCase):
         )
         perform_merging(client, 1)
 
+    @mock.patch("card_generator.cards.client.QueueCardsClient.login")
     @mock.patch("card_generator.cards.client.logger")
     @mock.patch("card_generator.cards.client.QueueCardsClient.get_queue_batch")
-    def test_merge_card_no_id_queue(self, mock_get_queue_batch, mock_logger):
+    def test_merge_card_no_id_queue(
+        self, mock_get_queue_batch, mock_logger, mock_login
+    ):
         mock_get_queue_batch.return_value = {"name": "no_id_queue", "id": 1}
+        mock_login.return_value = 1
         client = QueueCardsClient(
             server_root=settings.OPENSPP_SERVER_ROOT,
             username=settings.OPENSPP_USERNAME,
@@ -47,10 +54,14 @@ class TestMergeCardTask(OpenSPPClientTestMixin, TestCase):
         perform_merging(client, 1)
         mock_logger.info.assert_called_with("Batch ID 1 don't have queue IDs.")
 
+    @mock.patch("card_generator.cards.client.QueueCardsClient.login")
     @mock.patch("card_generator.tasks.cards.logger")
     @mock.patch("card_generator.cards.client.QueueCardsClient.get_queue_batch")
-    def test_merge_card_no_queue_batch(self, mock_get_queue_batch, mock_logger):
+    def test_merge_card_no_queue_batch(
+        self, mock_get_queue_batch, mock_logger, mock_login
+    ):
         mock_get_queue_batch.return_value = None
+        mock_login.return_value = 1
         client = QueueCardsClient(
             server_root=settings.OPENSPP_SERVER_ROOT,
             username=settings.OPENSPP_USERNAME,

--- a/card_generator/tasks/cards.py
+++ b/card_generator/tasks/cards.py
@@ -3,6 +3,7 @@ import tempfile
 
 from celery import shared_task
 from django.conf import settings
+from django.utils.timezone import now
 from PyPDF2 import PdfMerger
 
 from card_generator.cards.client import QueueCardsClient
@@ -35,7 +36,12 @@ def save_pdf_to_openspp(
     :param pdf_uri: URI formatted PDF
     :param filename: name of merged PDF
     """
-    data = {"id_pdf": pdf_uri, "merge_status": "merged", "id_pdf_filename": filename}
+    data = {
+        "id_pdf": pdf_uri,
+        "merge_status": "merged",
+        "id_pdf_filename": filename,
+        "date_merged": now().date().isoformat(),
+    }
     client.update_queue_batch_record(batch_id=batch_id, data=data)
 
 


### PR DESCRIPTION
When updating the queue batch with the merged PDF and status, also update the `date_merged` field.